### PR TITLE
dplyr::summarise is depreceated

### DIFF
--- a/R/cb_get_col_attributes.R
+++ b/R/cb_get_col_attributes.R
@@ -191,7 +191,7 @@ cb_get_col_attributes <- function(df, .x, keep_blank_attributes = keep_blank_att
   }
 
   attr_df <- df %>%
-    dplyr::summarise(
+    dplyr::reframe(
       `Column name:`                    = .x,
       `Column description:`             = description,
       `Source information:`             = attributes(df[[.x]])[["source"]],


### PR DESCRIPTION
dplyr has depreceated use of summarise when it returns more or less than one row per group. I switched to reframe as dplyr suggests. reframe returns an ungrouped table but I don't that is a problem here (?)

Codebookr returns a warning now:
Warning message:
Returning more (or less) than 1 row per `summarise()` group was deprecated in dplyr 1.1.0. ℹ Please use `reframe()` instead.
ℹ When switching from `summarise()` to `reframe()`, remember that `reframe()` always returns an ungrouped data frame and adjust accordingly.