### PR TITLE
Set R dependency to >= 4.1.0 and restore shorthand lambdas

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ URL: https://github.com/brad-cannell/codebookr,
     https://brad-cannell.github.io/codebookr/
 BugReports: https://github.com/brad-cannell/codebookr/issues
 Depends: 
-    R (>= 2.10)
+    R (>= 4.1.0)
 LazyData: true
 Suggests: 
     hms,


### PR DESCRIPTION
### Motivation
- The package previously used R 4.1 anonymous-function shorthand (`\(x)`) which triggers a CRAN NOTE unless the package declares `R (>= 4.1.0)`, so the dependency is raised to allow keeping the shorthand.

### Description
- Updated `DESCRIPTION` to require `R (>= 4.1.0)` and restored the shorthand anonymous functions (`\(x)`) in `R/cb_summary_stats_numeric.R` to preserve the original implementation style.

### Testing
- Verified the `DESCRIPTION` declaration contains `R (>= 4.1.0)` using `rg -n "^Depends|R \\(>= "` which succeeded.
- Verified shorthand lambdas are present in `R/cb_summary_stats_numeric.R` using `rg -n -F '\\(' R/cb_summary_stats_numeric.R` which succeeded.
- Attempted `R CMD check --no-manual .` but it could not be run because the `R` executable is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c98ad004c832180479de531aecafe)